### PR TITLE
Fix: Update manifests for ExtensionInstallForceList policy

### DIFF
--- a/updates.xml
+++ b/updates.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>
   <app appid='ocaahdebbfolfmndjeplogmgcagdmblk'>
-    <updatecheck codebase='https://github.com/NeverDecaf/chromium-web-store/releases/latest/download/Chromium.Web.Store.crx' version='1.5.3' status='ok' />
+    <updatecheck codebase='https://github.com/NeverDecaf/chromium-web-store/releases/latest/download/Chromium.Web.Store.crx' version='1.5.3.1' status='ok' />
   </app>
 </gupdate>

--- a/updates_en_nolocale.xml
+++ b/updates_en_nolocale.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>
   <app appid='ocaahdebbfolfmndjeplogmgcagdmblk'>
-    <updatecheck codebase='https://github.com/NeverDecaf/chromium-web-store/releases/latest/download/Chromium.Web.Store.crx' version='1.5.3' status='ok' />
+    <updatecheck codebase='https://github.com/NeverDecaf/chromium-web-store/releases/latest/download/Chromium.Web.Store.crx' version='1.5.3.1' status='ok' />
   </app>
 </gupdate>


### PR DESCRIPTION
Chrome refuses to force install the extension because the update manifests and the actual extension manifest versions doesn't match.

```
[143202:143202:0924/004054.232227:WARNING:load_error_reporter.cc(74)] Extension error: Expected version "1.5.3", but version was "1.5.3.1"
[143202:143202:0924/004054.557927:WARNING:force_installed_metrics.cc(481)] Failed to install 1 forced extensions.
[143202:143202:0924/004054.557949:WARNING:force_installed_metrics.cc(518)] Forced extension ocaahdebbfolfmndjeplogmgcagdmblk failed to install with data=failure_reason: 20; install_error_detail: 4; install_stage: 4; downloading_cache_status: 2
```