### PR TITLE
Return true in onMessageExternal

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -275,13 +275,13 @@ chrome.runtime.onMessageExternal.addListener(function (
                 const this_ext = exts.filter((extInfo) => extInfo.id === id);
                 if (!this_ext.length) {
                     sendResponse({ args: ["installable"] });
-                    return;
+                } else {
+                    sendResponse({
+                        args: [this_ext[0].enabled ? "enabled" : "disabled"],
+                    });
                 }
-                sendResponse({
-                    args: [this_ext[0].enabled ? "enabled" : "disabled"],
-                });
             });
-            break;
+            return true;
         case "getAll":
             var [href, ..._] = request.args;
             const target_ext = ncws_re.exec(href)?.[1];
@@ -291,7 +291,7 @@ chrome.runtime.onMessageExternal.addListener(function (
                     args: [exts.filter((extInfo) => extInfo.id === target_ext)],
                 });
             });
-            break;
+            return true;
         case "beginInstallWithManifest3":
             var [extInfo, href, ..._] = request.args;
 
@@ -307,6 +307,6 @@ chrome.runtime.onMessageExternal.addListener(function (
                 // The behaviour of this is similar to sending success ("") so this should be fine.
                 args: ["user_cancelled"],
             });
-            break;
+            return true;
     }
 });


### PR DESCRIPTION
This change makes the onMessageExternal function return true when sendResponse is used.  

CWS buttons were non-functional in builds of chromium 145 due to the change in [[7303890]](https://chromium-review.googlesource.com/c/chromium/src/+/7303890) which requires the function to return true or a promise to keep the channel open.  They worked normally with this change on builds of versions 145.0.7632.75, 144.0.7559.132, and 144.0.7559.59.  